### PR TITLE
Add support for macos

### DIFF
--- a/src/basicengine.cpp
+++ b/src/basicengine.cpp
@@ -26,6 +26,11 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#ifndef HOST_NAME_MAX
+#include <limits>
+#define HOST_NAME_MAX sysconf (_SC_HOST_NAME_MAX)
+#endif
+
 BasicEngine::BasicEngine ( const string& filename) : AbstractSchedulerEngine(filename){
   
   engineType="basic";


### PR DESCRIPTION
`HOST_NAME_MAX` is not defined in macOS.
