### PR TITLE
Add the @ workdir syntax

### DIFF
--- a/src/abstractengine.h
+++ b/src/abstractengine.h
@@ -1,17 +1,17 @@
-/* 
+/*
  * This file is part of GREASY software package
  * Copyright (C) by the BSC-Support Team, see www.bsc.es
- * 
+ *
  * GREASY is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 3
  * of the License, or (at your option) any later version.
- * 
+ *
  * GREASY is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GREASY. If not, see <http://www.gnu.org/licenses/>.
  *
@@ -62,15 +62,15 @@ public:
 
   /**
    * It provides all the initialization code. After init, engine should have parsed the task file and
-   * should be prepared to run the tasks and detect possible problems after it. If reimplemented, it 
+   * should be prepared to run the tasks and detect possible problems after it. If reimplemented, it
    * MUST be called from the subclass.
    */
   virtual void init() ;
-  
+
   /**
    * Abstract method to be implemented in subclasses. It should provide all the scheduling
    * code for the tasks, managing their creation, execution and completion and updating metadata
-   * objects accordingly. 
+   * objects accordingly.
    */
   virtual void run() = 0;
 
@@ -106,49 +106,61 @@ protected:
   /**
    * It parses the task file and fills up the taskMap. It also checks if the task is syntactically
    * valid or not.
-   */   
+   */
   void parseTaskFile();
-  
+
   /**
    * It checks all dependencies to see that there is no semantic error in any of them, and fills up
    * the revDepMap.
-   */     
+   */
   void checkDependencies();
-  
+
   /**
    * Helper function to record an invalid task. It adds an entry to the log, and if the strict
    * checking is enabled, will raise the fileErrors flag, preventing the engine from running.
-   */   
+   */
   void recordInvalidTask(int taskId);
-  
+
   /**
    * It produces a final summary of the execution of greasy, with some statistics on the tasks completed,
    * failed, etc., the total amount of time consumed and the resource utilitzation percentage.
    */
   void buildFinalSummary();
-  
+
   /**
   * Debug method to dump in a pretty format the contents of the taskMap.
-  */ 
+  */
   string dumpTaskMap();
+
+
+  /**
+  * Remove substrings inside a string
+  */
+  void removeSubStrs(string& str, const string& pattern) {
+   string::size_type n = pattern.length();
+   for (auto i = str.find(pattern);
+       i != string::npos;
+       i = str.find(pattern))
+       str.erase(i, n);
+   }
 
   string engineType; /**< Type of the engine. Each subclass will have a different type. */
   string taskFile; /**< Path to the file containing the tasks to execute. */
   string restartFile; /**< Path to the file where the restart will be written. */
   int nworkers; /**< Number of greasy workers (possibly the number of cpus available). */
   bool ready; /**< Flag to know if the engine is ready to run. */
-  
+
   map<int,GreasyTask*> taskMap; ///< Main task map linking the taskId (the line in the file)
 				///< with the actual GreasyTask object.
   set<int> validTasks; /**< Set containing the valid tasks read in the file. */
   map<int,list<int> > revDepMap; ///< Map that contains the reverse dependencies for each task.
 				 ///< Useful, for example, to know which tasks had dependencies
 				 ///< against a task that completed or failed.
-  
+
   GreasyLog *log; /**< log instance. */
   GreasyConfig *config; /**< config instance. */
   GreasyTimer globalTimer; /**< Global timer to count the time that engine takes to run. */
-  
+
 private:
   bool fileErrors; /**< Flag to know if there were any errors in the task file once processed. */
   bool strictChecking; /**< Flag to know if strict checking of the file is enabled. */
@@ -163,12 +175,12 @@ class AbstractEngineFactory {
 public:
   /**
     * Get the required AbstractEngine instance according to the type specified.
-    * @param filename The path to the task file 
+    * @param filename The path to the task file
     * @param type A string containing the type of the engine we want to build.
     * @return A pointer to the AbstractEngine instance.
     */
     static AbstractEngine* getAbstractEngineInstance(const string& filename, const string& type="" );
-	
+
 };
 
 

--- a/src/basicengine.cpp
+++ b/src/basicengine.cpp
@@ -1,17 +1,17 @@
-/* 
+/*
  * This file is part of GREASY software package
  * Copyright (C) by the BSC-Support Team, see www.bsc.es
- * 
+ *
  * GREASY is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 3
  * of the License, or (at your option) any later version.
- * 
+ *
  * GREASY is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GREASY. If not, see <http://www.gnu.org/licenses/>.
  *
@@ -32,19 +32,19 @@
 #endif
 
 BasicEngine::BasicEngine ( const string& filename) : AbstractSchedulerEngine(filename){
-  
+
   engineType="basic";
   remote = false;
 }
 
 void BasicEngine::init() {
-    
+
   char hostname[HOST_NAME_MAX];
-  
+
   log->record(GreasyLog::devel, "BasicEngine::init", "Entering...");
 
   AbstractSchedulerEngine::init();
-  
+
   gethostname(hostname, sizeof(hostname));
   masterHostname=hostname;
 
@@ -58,38 +58,38 @@ void BasicEngine::init() {
     } else {
       // Fill the workerNodes map
       for (int i=1;i<=nworkers; i++) {
-	workerNodes[i]=nodelist[i-1];
-	if (!isLocalNode(workerNodes[i])) remote = true;
+        workerNodes[i]=nodelist[i-1];
+        if (!isLocalNode(workerNodes[i])) remote = true;
       }
     }
-    
+
     if (remote) {
       if (config->keyExists("BasicRemoteMethod")){
-	if (config->getValue("BasicRemoteMethod")=="srun") {
-	  log->record(GreasyLog::debug,  "Using srun to spawn remote tasks");
-	} else if (config->getValue("BasicRemoteMethod")=="ssh") {
-	  log->record(GreasyLog::debug,  "Using ssh to spawn remote tasks");
-	} else {
-	  log->record(GreasyLog::error,  "No Basic Spawner in the system. Please run greasy locally unsetting the NodeList Parameter");
-	  ready = false;
-	}
+        if (config->getValue("BasicRemoteMethod")=="srun") {
+          log->record(GreasyLog::debug,  "Using srun to spawn remote tasks");
+        } else if (config->getValue("BasicRemoteMethod")=="ssh") {
+          log->record(GreasyLog::debug,  "Using ssh to spawn remote tasks");
+        } else {
+          log->record(GreasyLog::error,  "No Basic Spawner in the system. Please run greasy locally unsetting the NodeList Parameter");
+          ready = false;
+        }
       } else {
-	 log->record(GreasyLog::error,  "No Basic Remote method configured. Please run greasy locally unsetting the NodeList Parameter");
-	 ready = false;
-      }      
+        log->record(GreasyLog::error,  "No Basic Remote method configured. Please run greasy locally unsetting the NodeList Parameter");
+        ready = false;
+      }
     }
 
   }
 
-   
+
   log->record(GreasyLog::devel, "BasicEngine::init", "Exiting...");
-  
+
 }
 
 void BasicEngine::run() {
-  
+
   log->record(GreasyLog::devel, "BasicEngine::run", "Entering...");
-  
+
   if (isReady()) runScheduler();
 
   log->record(GreasyLog::devel, "BasicEngine::run", "Exiting...");
@@ -97,74 +97,74 @@ void BasicEngine::run() {
 }
 
 void BasicEngine::allocate(GreasyTask* task) {
-  
+
   int worker;
-  
+
   log->record(GreasyLog::devel, "BasicEngine::allocate", "Entering...");
-  
+
   log->record(GreasyLog::info,  "Allocating task " + toString(task->getTaskId()));
-  
+
   worker = freeWorkers.front();
   freeWorkers.pop();
   taskAssignation[worker] = task->getTaskId();
-  
+
   pid_t pid = fork();
-  
+
   if (pid == 0) {
     // Child:
     // Disable signal handling in child processes
     // We only want to have the master in charge of the restarts and messages.
     signal(SIGTERM, SIG_DFL);
     signal(SIGINT, SIG_DFL);
-   
+
     // We use system instead of exec because of greater compatibility with command to be executed
-    exit(executeTask(task,worker));  
+    exit(executeTask(task,worker));
   } else if (pid > 0) {
     // Parent:
-    log->record(GreasyLog::debug,  "BasicEngine::allocate", "Task " 
-		      + toString(task->getTaskId()) + " to worker " + toString(worker)
-		      + " on node " + getWorkerNode(worker));
+    log->record(GreasyLog::debug,  "BasicEngine::allocate", "Task "
+              + toString(task->getTaskId()) + " to worker " + toString(worker)
+              + " on node " + getWorkerNode(worker));
     pidToWorker[pid] = worker;
     task->setTaskState(GreasyTask::running);
     workerTimers[worker].reset();
     workerTimers[worker].start();
-    
+
   } else {
-   //error 
+   //error
    log->record(GreasyLog::error,  "Could not execute a new process");
    task->setTaskState(GreasyTask::failed);
    task->setReturnCode(-1);
    freeWorkers.push(worker);
   }
-  
+
   log->record(GreasyLog::devel, "BasicEngine::allocate", "Exiting...");
-  
+
 }
 
 void BasicEngine::waitForAnyWorker() {
-  
+
   int retcode = -1;
   int worker;
   pid_t pid;
   int status;
   GreasyTask* task = NULL;
-  
+
   log->record(GreasyLog::devel, "BasicEngine::waitForAnyWorker", "Entering...");
 
   // Wait for any of the worker to finish
   log->record(GreasyLog::debug,  "Waiting for any task to complete...");
   pid = wait(&status);
-  
+
   // Identify the worker that was in charge of the child
   worker = pidToWorker[pid];
-  
+
   // Get the return code
   if (WIFEXITED(status)) retcode = WEXITSTATUS(status);
-    
+
   // Push worker to the free workers queue again
   freeWorkers.push(worker);
   workerTimers[worker].stop();
-  
+
   // Update task info
   task = taskMap[taskAssignation[worker]];
   task->setReturnCode(retcode);
@@ -173,14 +173,14 @@ void BasicEngine::waitForAnyWorker() {
 
   // Run task epilogue stuff
   taskEpilogue(task);
-  
+
   log->record(GreasyLog::devel, "BasicEngine::waitForAnyWorker", "Exiting...");
-  
+
 }
 
 int BasicEngine::executeTask(GreasyTask *task, int worker) {
-  
-  log->record(GreasyLog::devel, "BasicEngine::executeTask["+toString(worker) +"]", "Entering..."); 
+
+  log->record(GreasyLog::devel, "BasicEngine::executeTask["+toString(worker) +"]", "Entering...");
   string command = "";
   string node = "";
   int ret;
@@ -189,38 +189,48 @@ int BasicEngine::executeTask(GreasyTask *task, int worker) {
     node = masterHostname;
   } else {
     node = workerNodes[worker];
+  }
+
+  if(task->hasWorkDir()) {
+    command = "cd " + task->getWorkDir() + " && ";
+  }
+
+  // Always emitting the srun command, even on the master node
+  // Some sites may have SPANK plugins for the job step
+  if (config->getValue("BasicRemoteMethod")=="srun") {
+    command += "srun -n 1 -N 1 -w " + node + " " + task->getCommand();
+  }
+
+  // The ssh method
+  if (config->getValue("BasicRemoteMethod")=="ssh") {
+    // the ssh method doesn't have any sort of pinning mechanism, therefore one
+    // can avoid a ssh call when executing tasks on the masternode
     if (!isLocalNode(node)) {
-	if (config->getValue("BasicRemoteMethod")=="srun") {
-	  command = "srun -n 1 -N 1 -w " + node + " ";
-	} else if (config->getValue("BasicRemoteMethod")=="ssh") {
-	  command = "ssh -q " + node + " " ;
-	} else {
-	  // Should never be here
-	  log->record(GreasyLog::error, "Unknown error. Check BasicRemoteMethod parameter.");
-	} 
+      command = "ssh -q " + node + " \"" + command + task->getCommand() + "\"";
+    } else {
+      command += task->getCommand();
     }
   }
-  
-  command += task->getCommand();
-  log->record(GreasyLog::devel,  "BasicEngine::executeTask[" + toString(worker) +"]", "Task " 
-		      + toString(task->getTaskId()) + " on node " + node + " command: " + command);
+
+  log->record(GreasyLog::devel,  "BasicEngine::executeTask[" + toString(worker) +"]", "Task "
+              + toString(task->getTaskId()) + " on node " + node + " with command: " + command);
   ret =  system(command.c_str());
   ret = WEXITSTATUS(ret);
-  log->record(GreasyLog::devel, "BasicEngine::executeTask["+toString(worker) +"]", "Task returned "+toString(ret)); 
-  log->record(GreasyLog::devel, "BasicEngine::executeTask["+toString(worker) +"]", "Exiting..."); 
+  log->record(GreasyLog::devel, "BasicEngine::executeTask["+toString(worker) +"]", "Task returned "+toString(ret));
+  log->record(GreasyLog::devel, "BasicEngine::executeTask["+toString(worker) +"]", "Exiting...");
   return ret;
-  
+
 }
 
 bool BasicEngine::isLocalNode(string node) {
-  
+
   return ((node == masterHostname)||(node == "localhost"));
-  
+
 }
 
 string BasicEngine::getWorkerNode(int worker) {
-  
+
   if (remote) return workerNodes[worker];
   else return masterHostname;
-  
+
 }

--- a/src/greasytask.h
+++ b/src/greasytask.h
@@ -1,17 +1,17 @@
-/* 
+/*
  * This file is part of GREASY software package
  * Copyright (C) by the BSC-Support Team, see www.bsc.es
- * 
+ *
  * GREASY is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 3
  * of the License, or (at your option) any later version.
- * 
+ *
  * GREASY is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GREASY. If not, see <http://www.gnu.org/licenses/>.
  *
@@ -27,24 +27,24 @@ using namespace std;
 
 /**
   * This class represents a Greasy task, corresponding to a line in the Greasy Task File.
-  * 
+  *
   */
 
 class GreasyTask
 {
-  
+
 public:
-  
-  /** 
+
+  /**
   * Possible task states.
   */
   enum TaskStates {
           invalid, /** Task is not valid. contains syntax error(s) or invalid dependencies */
-	  blocked, /**< Task is blocked waiting for some dependencies to complete. */
-	  waiting, /**< Task is waiting to be scheduled. */
-	  running, /**< Task is running.  */
-	  completed, /**< Task has completed fine. */
-	  failed, /**< Task has failed for some reason. */
+      blocked, /**< Task is blocked waiting for some dependencies to complete. */
+      waiting, /**< Task is waiting to be scheduled. */
+      running, /**< Task is running.  */
+      completed, /**< Task has completed fine. */
+      failed, /**< Task has failed for some reason. */
           cancelled /**< Task has been cancelled because of dependencies failed. */
   } ;
 
@@ -52,12 +52,12 @@ public:
    * Empty Constructor.
    */
   GreasyTask ( );
-  
+
   /**
    * Simple Constructor to fill taskId and command.
-   */  
+   */
   GreasyTask ( int id, string cmd );
-  
+
   /**
    * Get the value of taskId.
    * @return the value of taskId.
@@ -69,7 +69,7 @@ public:
    * @return the value of taskNum.
    */
   int getTaskNum ( );
-  
+
     /**
    * Set the value of taskId.
    * @param new_var the new value of taskId.
@@ -80,7 +80,7 @@ public:
    * Set the value of taskNum.
    * @param new_var the new value of taskId.
    */
-	void setTaskNum ( int new_var );
+    void setTaskNum ( int new_var );
 
   /**
    * Get the value of command.
@@ -128,87 +128,87 @@ public:
    * Set the task state to state.
    * @param state The state of the task, a value from TaskStates.
    */
-  void setTaskState(TaskStates state); 
-  
+  void setTaskState(TaskStates state);
+
   /**
    * Get the (last) return code of the task.
    * @return The exit code from the task.
    */
   int getReturnCode();
-  
+
   /**
    * Set the return code of the task to code.
    * @param code the new exit code.
-   */  
+   */
   void setReturnCode(int code);
-  
+
   /**
    * Get the last value of elapsed time of the task.
    * @return the elapsed time in seconds of the task.
-   */  
+   */
   unsigned long getElapsedTime();
 
   /**
-   * Get the accumulated value of elapsed time of the task 
+   * Get the accumulated value of elapsed time of the task
    * along the retries.
    * @return the total elapsed time in seconds of the task.
-   */  
+   */
   unsigned long getElapsedTimeAcc();
-  
+
   /**
    * Set the elapsed time of the task. The time will be also
    * added to the total counter elapsedAcc.
    * @param et the elapsed time in seconds.
-   */    
+   */
   void setElapsedTime(unsigned long et);
-  
+
   /**
    * Get the hostname where this task run.
    * @return the hostname.
-   */    
+   */
   string getHostname();
 
   /**
    * Set the hostname where this task run.
    * @param h the hostname.
-   */   
+   */
   void setHostname(string h);
 
   /**
    * Get the number of retries performed with this task.
    * @return the number of retries.
-   */     
+   */
   int getRetries();
 
   /**
    * Adds a retry attempt to the counter.
-   */       
+   */
   void addRetryAttempt();
-  
+
   /**
    * Checks if the task has dependencies.
    * @return true if the task has dependencies, false otherwise.
-   */     
+   */
   bool hasDependencies();
-  
+
   /**
    * Obtain the list of dependencies as taskIds.
    * @return a list of taskIds
-   */   
+   */
   list<int> getDependencies();
-  
+
   /**
    * Adds the dependency parentTask to the list.
    * @param parentTask the parent task on which this task depends.
-   */     
+   */
   void addDependency(int parentTask);
 
   /**
    * Removes the dependency parentTask from the list.
    * @param parentTask the parent task on which this task depends.
-   */     
+   */
   void removeDependency(int parentTask);
-  
+
   /**
    * Add task depenencies as written in the task file. It will parse the contents
    * of [# deps #]. Deps contains a list of comma separated tokens, which can be:
@@ -217,31 +217,53 @@ public:
    *   - a range of numbers. Example 3-6
    * @param deps a string with the dependencies written as in the task file.
    * @return true if all went fine, false otherwise.
-   */     
+   */
   bool addDependencies(string deps);
-  
+
   /**
    * Debug function that generates a pretty string with the task contents.
    * @return string with pretty task contents.
-   */     
+   */
   string dump();
 
   /**
    * Debug function that generates a pretty string with the task dependencies.
    * @return string with pretty task contents.
-   */    
+   */
   string dumpDependencies();
-  
+
+  /**
+   * Checks if the task has a dedicated workdir.
+   * @return true if the task has a dedicated workdir, false otherwise.
+   */
+  bool hasWorkDir() {
+    return !workdir.empty();
+  }
+
+  /**
+   * Obtain the task dedicated workdir.
+   * @return the task dedicated workdir
+   */
+  string getWorkDir() const {
+    return this->workdir;
+  }
+  /**
+   * Set a dedicated workdir to the task.
+   * @param workdir the dedicated workdir for this task.
+   */
+  void setWorkDir(string workdir) {
+    this->workdir = workdir;
+  }
 
 protected:
-  
+
   /**
    * Init Attributes of the task
    */
   void initAttributes ( ) ;
 
   int taskId;  /**< Task id corresponding to the line of the file (starting at 1). */
-	int taskNum; /**< Real number of the task (ignoring comments). */
+    int taskNum; /**< Real number of the task (ignoring comments). */
   string command; /**< Command to be executed. */
   int taskState; /**< Task state at a given time. */
   string hostname; /**< Return code of the executed command. */
@@ -250,6 +272,7 @@ protected:
   unsigned long elapsed; /**< Seconds elapsed of the last execution of the task. */
   unsigned long elapsedAcc; /**< Seconds elapsed accumulated among retries. */
   list<int> dependencies; /**< List of the taskIds of the dependencies. */
+  string workdir; /**< Dedicated workdir for the task. */
 
 };
 

--- a/src/mpiengine.cpp
+++ b/src/mpiengine.cpp
@@ -152,14 +152,19 @@ void MPIEngine::allocate(GreasyTask* task) {
 
   log->record(GreasyLog::info,  "Allocating task " + toString(task->getTaskNum()) + " located in line "+ toString(task->getTaskId()) + " to Worker " + toString(worker));
 
-  log->record(GreasyLog::debug, "MPIEngine::allocate", "Sending task " + toString(task->getTaskNum()) + " located in line "+ toString(task->getTaskId()) + " to worker " + toString(worker));
   taskAssignation[worker] = task->getTaskId();
   task->setTaskState(GreasyTask::running);
+
+  if(task->hasWorkDir()) {
+    string command = "cd " + task->getWorkDir() + " && " + task->getCommand();
+    task->setCommand(command);
+  }
+  log->record(GreasyLog::debug,  "Task " + toString(task->getTaskNum()) + " located in line "+ toString(task->getTaskId()) + " to Worker " + toString(worker) + " wants to execute " + task->getCommand());
 
   // Send the command size and the actual command
   cmdSize = task->getCommand().size()+1;
   MPI_Send(&cmdSize, 1, MPI_INT, worker, 0, MPI_COMM_WORLD);
-  MPI_Send((void*)task->getCommand().c_str(), cmdSize, MPI_BYTE, worker, 0, MPI_COMM_WORLD);
+  MPI_Send((void*) task->getCommand().c_str(), cmdSize, MPI_BYTE, worker, 0, MPI_COMM_WORLD);
 
   log->record(GreasyLog::devel, "MPIEngine::allocate", "Exiting...");
 

--- a/src/threadengine.cpp
+++ b/src/threadengine.cpp
@@ -1,17 +1,17 @@
-/* 
+/*
  * This file is part of GREASY software package
  * Copyright (C) by the BSC-Support Team, see www.bsc.es
- * 
+ *
  * GREASY is free software: you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 3
  * of the License, or (at your option) any later version.
- * 
+ *
  * GREASY is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GREASY. If not, see <http://www.gnu.org/licenses/>.
  *
@@ -22,7 +22,7 @@
 
 
 ThreadEngine::ThreadEngine ( const string& filename) : AbstractEngine(filename){
-  
+
   engineType="thread";
 
 }
@@ -124,14 +124,16 @@ void GreasyTBBTaskEngine::operator()( argument_type item, tbb::parallel_do_feede
 {
     GreasyLog::getInstance()->record(GreasyLog::devel, "GreasyTBBTaskEngine::()", "Entering...");
 
-    GreasyLog::getInstance()->record(GreasyLog::debug, "GreasyTBBTaskEngine::()", "Executing command: " + item->getCommand());
+    string command = "cd " + item->getWorkDir() + " && " + item->getCommand() + item->getCommand();
+
+    GreasyLog::getInstance()->record(GreasyLog::debug, "GreasyTBBTaskEngine::()", "Executing command: " + command);
 
     item->setTaskState(GreasyTask::running);
 
     GreasyTimer timer;
     timer.reset();
     timer.start();
-    int retcode = system(item->getCommand().c_str());
+    int retcode = system(command.c_str());
     timer.stop();
 
     item->setReturnCode(retcode);
@@ -245,5 +247,3 @@ void GreasyTBBTaskEngine::updateDependencies(argument_type child, tbb::parallel_
     log->record(GreasyLog::devel, "GreasyTBBTaskEngine::updateDependencies", "Exiting...");
 
 }
-
-


### PR DESCRIPTION
This introduces the `[@ workdir @]` syntax. In this syntax the users can
change dir just before the execution of a given task.
The feature may seem strange at first because users can easily add tasks
that have `cd` commands before the executable call. However, the `cd`
command does not work for basic engine combined with the srun method.
Therefore it is necessary to introduce such feature.

All engines and run methods implement this feature, therefore it is easy
for the end user to migrate task files between greasy installation that
use different engines.

Additionally, the logic of emitting `srun` commands for the basic engine
is slightly different from the original code. In this implementation one
always emit the srun command even when executing tasks in the master
node. This is due to the fact that SLURM allows for SPANK plugins to be
defined for each job step (`srun` call). In order to avoid that some
tasks are executed as job steps and others not, then one needs to always
invoke thes tasks using the `srun` command.

In practice, the task file can look like
```
[@ $HOME/01 @]  hostname && pwd
[@ $HOME/02 @]  hostname && pwd
...
```
where `$HOME/01` and `$HOME/02` are distinct folders where the command `hostname && pwd` will be executed.